### PR TITLE
Add arm

### DIFF
--- a/.github/workflows/docker-hub-ci.yaml
+++ b/.github/workflows/docker-hub-ci.yaml
@@ -2,7 +2,7 @@ name: Docker Hub CI
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "add_arm" ]
 
 jobs:
   build:

--- a/.github/workflows/docker-hub-ci.yaml
+++ b/.github/workflows/docker-hub-ci.yaml
@@ -2,7 +2,7 @@ name: Docker Hub CI
 
 on:
   push:
-    branches: [ "add_arm" ]
+    branches: [ "master" ]
 
 jobs:
   build:

--- a/.github/workflows/docker-hub-ci.yaml
+++ b/.github/workflows/docker-hub-ci.yaml
@@ -1,0 +1,33 @@
+name: Docker Hub CI
+
+on:
+  push:
+    branches: [ "master" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/dadjokes:latest
+          platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
Handy little GitHub action to auto build for x86 and ARM and push the image to Docker Hub.

Will require you to add two repo secrets: DOCKERHUB_USERNAME and DOCKERHUB_TOKEN but after that, on a pus to master, you'll have images built for both popular architectures and have them loaded into Docker Hub.

I've tested both the build process for Dadjokes and the resulting image on Apple Silicon.

Let me know if you have any questions @nikirago 